### PR TITLE
修复了开火RPC问题

### DIFF
--- a/Assets/Common/Network/Scripts/NetSyncController.cs
+++ b/Assets/Common/Network/Scripts/NetSyncController.cs
@@ -40,6 +40,17 @@ public class NetSyncController : MonoBehaviour
         NetMgr.srvConn.msgDist.AddListener(sync_id + "RPC", RecvRPC);
     }
 
+    public void setSyncID(string _sync_id)
+    {
+        if (!GameMgr.instance)//GameMgr.instance没被初始化，则此时是离线状态
+            return;
+        NetMgr.srvConn.msgDist.DelListener(sync_id + "NetSyncController", RecvNetSync);
+        NetMgr.srvConn.msgDist.DelListener(sync_id + "RPC", RecvRPC);
+        sync_id = _sync_id;
+        NetMgr.srvConn.msgDist.AddListener(sync_id + "NetSyncController", RecvNetSync);
+        NetMgr.srvConn.msgDist.AddListener(sync_id + "RPC", RecvRPC);
+    }
+
     void SendNetSync()
     {
         if (!GameMgr.instance)//GameMgr.instance没被初始化，则此时是离线状态

--- a/Assets/Common/Network/Scripts/SceneNetManager.cs
+++ b/Assets/Common/Network/Scripts/SceneNetManager.cs
@@ -101,8 +101,10 @@ public class SceneNetManager : MonoBehaviour
         foreach (var temp in net_sync_controllers)
         {
             temp.name = id + temp.name;
+            temp.setSyncID(temp.name);//确保sync_id正确
         }
         playerObj.name = id;
+        playerObj.GetComponent<NetSyncController>().setSyncID(playerObj.name);//确保sync_id正确
 
         playerObj.transform.position = swopTrans.position;
         playerObj.transform.rotation = swopTrans.rotation;


### PR DESCRIPTION
该问题系由于AI同步将NetSyncController的初始化时间提前至Awake，
在SceneNetManager中改完名后再次设置sync_id修复